### PR TITLE
Small fix to prevent syntax errors from happening (empty string in JS…

### DIFF
--- a/lib/webhelper.js
+++ b/lib/webhelper.js
@@ -93,7 +93,7 @@ function WebHelper(credentials, hostName) {
 				str += chunk
 			})
 			response.on('end', function() {
-				next(null, JSON.parse(str))
+				next(null, (str.length > 0) ? JSON.parse(str) : null)
 			})
 			response.on('error', function(err) {
 				next(err, null)


### PR DESCRIPTION
Small fix to prevent syntax errors from happening (empty string in JSON.parse will throw syntax error)