### PR TITLE
Fixes POST requests to properly retrieve apiKey

### DIFF
--- a/lib/webhelper.js
+++ b/lib/webhelper.js
@@ -67,7 +67,7 @@ function WebHelper(credentials, hostName) {
                     path: path,
                     port: 443,
                     headers: {
-                        "Api-Key": credentials.ApiKey,
+                        "Api-Key": credentials.apiKey,
                         "Authorization": "Bearer " + response.access_token,
                         "Content-Length": 0
                     }
@@ -96,8 +96,8 @@ function WebHelper(credentials, hostName) {
                     var err = new Error("Not Found");
                     err.statusCode = response.statusCode;
                     next(err, null);
-                    
-                } else {                
+
+                } else {
                     next(null, (str.length > 0) ? JSON.parse(str) : null);
                 }
             });


### PR DESCRIPTION
Without this fix, post requests will yield:

```
Error: `value` required in setHeader("Api-Key", value).
    at ClientRequest.OutgoingMessage.setHeader (_http_outgoing.js:342:11)
    at new ClientRequest (_http_client.js:86:14)
    at Object.exports.request (http.js:31:10)
    at Object.exports.request (https.js:177:15)
```