### PR TITLE
Remove license_model from Image Search

### DIFF
--- a/lib/searchimages.js
+++ b/lib/searchimages.js
@@ -22,7 +22,6 @@ class SearchImages extends GettyApiRequest {
         this.fileTypes = [];
         this.graphicalStyles = [];
         this.keywordIds = [];
-        this.licenseModels = [];
         this.minimumSize = null;
         this.numberOfPeople = [];
         this.orientations = [];
@@ -53,7 +52,6 @@ class SearchImages extends GettyApiRequest {
         addParameter(params, "file_types", this.fileTypes);
         addParameter(params, "graphical_styles", this.graphicalStyles);
         addParameter(params, "keyword_ids", this.keywordIds);
-        addParameter(params, "license_models", this.licenseModels);
         addParameter(params, "minimum_size", this.minimumSize);
         addParameter(params, "number_of_people", this.numberOfPeople);
         addParameter(params, "orientations", this.orientations);
@@ -132,10 +130,6 @@ class SearchImages extends GettyApiRequest {
     }
     withKeywordId(keywordId) {
         this.keywordIds[this.keywordIds.length] = keywordId;
-        return this;
-    }
-    withLicenseModel(licenseModel) {
-        this.licenseModels[this.licenseModels.length] = licenseModel;
         return this;
     }
     withMinimumSize(minimumSize) {

--- a/lib/searchimagescreative.js
+++ b/lib/searchimagescreative.js
@@ -21,7 +21,6 @@ class SearchImagesCreative extends GettyApiRequest {
         this.fileTypes = [];
         this.graphicalStyles = [];
         this.keywordIds = [];
-        this.licenseModels = [];
         this.minimumSize = null;
         this.numberOfPeople = [];
         this.orientations = [];
@@ -49,7 +48,6 @@ class SearchImagesCreative extends GettyApiRequest {
         addParameter(params, "file_types", this.fileTypes);
         addParameter(params, "graphical_styles", this.graphicalStyles);
         addParameter(params, "keyword_ids", this.keywordIds);
-        addParameter(params, "license_models", this.licenseModels);
         addParameter(params, "minimum_size", this.minimumSize);
         addParameter(params, "number_of_people", this.numberOfPeople);
         addParameter(params, "orientations", this.orientations);
@@ -123,10 +121,6 @@ class SearchImagesCreative extends GettyApiRequest {
     }
     withKeywordId(keywordId) {
         this.keywordIds[this.keywordIds.length] = keywordId;
-        return this;
-    }
-    withLicenseModel(licenseModel) {
-        this.licenseModels[this.licenseModels.length] = licenseModel;
         return this;
     }
     withMinimumSize(minimumSize) {

--- a/tests/searchimagescreativetests.js
+++ b/tests/searchimagescreativetests.js
@@ -53,9 +53,6 @@ test.beforeEach(t=>{
             .query({ "keyword_ids": [1234, 5678].join(","), "phrase": "cat" })
             .reply(200, {response : "response"})
             .get("/v3/search/images/creative")
-            .query({ "license_models": ["rightsmanaged", "royaltyfree"].join(","), "phrase": "cat" })
-            .reply(200, {response : "response"})
-            .get("/v3/search/images/creative")
             .query({ "minimum_size": "small", "phrase": "cat" })
             .reply(200, {response : "response"})
             .get("/v3/search/images/creative")
@@ -180,13 +177,6 @@ test("SearchImagesCreative: withGraphicalStyle will include graphical_styles in 
 test("SearchImagesCreative: withKeywordId will include keyword_ids in query", t => {  
     var client = new api({ apiKey: "apikey", apiSecret: "apisecret" }, null);
     return Promise.resolve(client.searchimagescreative().withPhrase("cat").withKeywordId([1234, 5678]).execute()).then(res => {
-        t.is(res.response, "response");
-    });
-});
-
-test("SearchImagesCreative: withLicenseModel will include license_models in query", t => {  
-    var client = new api({ apiKey: "apikey", apiSecret: "apisecret" }, null);
-    return Promise.resolve(client.searchimagescreative().withPhrase("cat").withLicenseModel(["rightsmanaged", "royaltyfree"]).execute()).then(res => {
         t.is(res.response, "response");
     });
 });

--- a/tests/searchimagestests.js
+++ b/tests/searchimagestests.js
@@ -56,9 +56,6 @@ test.beforeEach(t=>{
             .query({ "keyword_ids": [1234, 5678].join(","), "phrase": "cat" })
             .reply(200, {response : "response"})
             .get("/v3/search/images")
-            .query({ "license_models": ["rightsmanaged", "royaltyfree"].join(","), "phrase": "cat" })
-            .reply(200, {response : "response"})
-            .get("/v3/search/images")
             .query({ "minimum_size": "small", "phrase": "cat" })
             .reply(200, {response : "response"})
             .get("/v3/search/images")
@@ -193,13 +190,6 @@ test("SearchImages: withGraphicalStyle will include graphical_styles in query", 
 test("SearchImages: withKeywordId will include keyword_ids in query", t => {  
     var client = new api({ apiKey: "apikey", apiSecret: "apisecret" }, null);
     return Promise.resolve(client.searchimages().withPhrase("cat").withKeywordId([1234, 5678]).execute()).then(res => {
-        t.is(res.response, "response");
-    });
-});
-
-test("SearchImages: withLicenseModel will include license_models in query", t => {  
-    var client = new api({ apiKey: "apikey", apiSecret: "apisecret" }, null);
-    return Promise.resolve(client.searchimages().withPhrase("cat").withLicenseModel(["rightsmanaged", "royaltyfree"]).execute()).then(res => {
         t.is(res.response, "response");
     });
 });


### PR DESCRIPTION
Remove license_model from Image Search and Creative Image Search.
Remove license_model unit tests.