### PR TITLE
Allow making some calls with only an API key

### DIFF
--- a/gettyimages-api.js
+++ b/gettyimages-api.js
@@ -47,10 +47,6 @@ class GettyImagesApi {
             throw new SdkException("must specify an apiKey");
         }
 
-        if (!credentials.apiSecret) {
-            throw new SdkException("must specify an apiSecret");
-        }
-
         if (!hostName) {
             hostName = "api.gettyimages.com";
         }

--- a/tests/searchimagescreativetests.js
+++ b/tests/searchimagescreativetests.js
@@ -242,3 +242,9 @@ test ("SearchImagesCreative: withAcceptLanguage will include the Accept-Language
     t.is(body.headers["accept-language"], "en-us");
     t.is(body.response, "accept-language");
 });
+
+test("SearchImagesCreative: succeeds with only API Key and withPhrase will include phrase in query", async t => {  
+    var client = new api({ apiKey: "apikey" }, null);
+    const res = await client.searchimagescreative().withPhrase("cat").execute();
+    t.is(res.response, "phrase");
+});


### PR DESCRIPTION
Some users of the API want to be able to make calls like search with only an API key.