### PR TITLE
Fix error handling in https.request function

### DIFF
--- a/lib/webhelper.js
+++ b/lib/webhelper.js
@@ -126,32 +126,36 @@ function WebHelper(credentials, hostName) {
         addUserAgentString(options);
 
         return new Promise((resolve, reject) => {
-            var request = https.request(options, function (response) {
+            try {
+                var request = https.request(options, function (response) {
 
-                response.setEncoding("utf8");
-                var str = "";
+                    response.setEncoding("utf8");
+                    var str = "";
 
-                response.on("data", function (chunk) {
-                    str += chunk;
-                });
-                response.on("end", function () {
-                    if (response.statusCode >= 400) {
-                        var err = new Error(response.statusMessage);
-                        err.statusCode = response.statusCode;
+                    response.on("data", function (chunk) {
+                        str += chunk;
+                    });
+                    response.on("end", function () {
+                        if (response.statusCode >= 400) {
+                            var err = new Error(response.statusMessage);
+                            err.statusCode = response.statusCode;
+                            reject(err);
+
+                        } else {
+                            resolve((str.length > 0) ? JSON.parse(str) : null);
+                        }
+                    });
+                    response.on("error", function (err) {
                         reject(err);
-
-                    } else {
-                        resolve((str.length > 0) ? JSON.parse(str) : null);
-                    }
+                    });
                 });
-                response.on("error", function (err) {
-                    reject(err);
-                });
-            });
-            if (postData) {
-                request.write(postData);
+                if (postData) {
+                    request.write(postData);
+                }
+                request.end();
+            } catch (err) {
+                reject(err);
             }
-            request.end();
         });
     }
 


### PR DESCRIPTION
This commit addresses an issue with error handling in the https.request function. Previously, exceptions were not properly caught and handled, resulting in unexpected behaviour. The fix includes implementing proper error handling logic.

Now, network errors, invalid URLs, and SSL/TLS certificate errors are handled gracefully, improving the reliability of the function.

Example error:
![image](https://github.com/gettyimages/gettyimages-api_nodejs/assets/13791232/39d27d05-f15b-44ff-b426-f974517df61e)
