### PR TITLE
Upgrade upload-artifact action to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     - run: npm ci
     - run: npm test
     - run: npm pack
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: package
         path: ./gettyimages-api-${{ steps.previoustag.outputs.tag }}.tgz


### PR DESCRIPTION
- Addressing build failure [here](https://github.com/gettyimages/gettyimages-api_nodejs/actions/runs/17330277435).
- Due to [`upload-artifact` version deprecation](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)