### PR TITLE
Use date_from / date_to to match documented names in editorial searches

### DIFF
--- a/lib/searchimageseditorial.js
+++ b/lib/searchimageseditorial.js
@@ -65,7 +65,7 @@ class SearchImages extends GettyApiRequest {
         super.addParameter("product_types", this.productTypes);
         super.addParameter("sort_order", this.sortOrder);
         super.addParameter("specific_people", this.specificPeople);
-        super.addParameter("start_date", this.startDate);
+        super.addParameter("date_from", this.startDate);
 
         var path = "/v3/search/images/editorial";
         var query = querystring.stringify(this.params);

--- a/lib/searchvideoseditorial.js
+++ b/lib/searchvideoseditorial.js
@@ -45,7 +45,7 @@ class SearchVideosEditorial extends GettyApiRequest {
         super.addParameter("product_types", this.productTypes);
         super.addParameter("sort_order", this.sortOrder);
         super.addParameter("specific_people", this.specificPeople);
-        super.addParameter("start_date", this.startDate);
+        super.addParameter("date_from", this.startDate);
         super.addParameter("end_date", this.endDate);
         super.addParameter("orientations", this.orientations);
 

--- a/tests/searchimageseditorialtests.js
+++ b/tests/searchimageseditorialtests.js
@@ -93,8 +93,8 @@ test.beforeEach(() => {
         .query({ "specific_people": "reggie jackson", "phrase": "cat" })
         .reply(200, {response : "specific_people"})
         .get("/v3/search/images/editorial")
-        .query({ "start_date": "2015-04-01", "phrase": "cat" })
-        .reply(200, {response : "start_date"})
+        .query({ "date_from": "2015-04-01", "phrase": "cat" })
+        .reply(200, {response : "date_from"})
         .get("/v3/search/images/editorial")
         .query({"phrase":"monkey"})
         .reply(200,function(path, reqBody, cb) {
@@ -264,10 +264,10 @@ test("SearchImagesEditorial: withSpecificPeople will include specific_people in 
     t.is(res.response, "specific_people");
 });
 
-test("SearchImagesEditorial: withStartDate will include start_date in query", async t => {  
+test("SearchImagesEditorial: withStartDate will include date_from in query", async t => {  
     var client = new api({ apiKey: "apikey", apiSecret: "apisecret" }, null);
     const res = await client.searchimageseditorial().withPhrase("cat").withStartDate("2015-04-01").execute();
-    t.is(res.response, "start_date");
+    t.is(res.response, "date_from");
 });
 
 test ("SearchImagesEditorial: withAcceptLanguage will include the Accept-Languaged header in request", async t => {

--- a/tests/searchvideoseditorialtests.js
+++ b/tests/searchvideoseditorialtests.js
@@ -60,8 +60,8 @@ test.beforeEach(() => {
         .query({ "specific_people": "reggie jackson", "phrase": "cat" })
         .reply(200, {response : "specific_people"})
         .get("/v3/search/videos/editorial")
-        .query({ "start_date": "2023-01-01", "phrase": "cat" })
-        .reply(200, {response : "start_date"})
+        .query({ "date_from": "2023-01-01", "phrase": "cat" })
+        .reply(200, {response : "date_from"})
         .get("/v3/search/videos/editorial")
         .query({ "end_date": "2023-12-31", "phrase": "cat" })
         .reply(200, {response : "end_date"})
@@ -171,10 +171,10 @@ test("SearchVideosEditorial: withSpecificPeople will include specific_people in 
     t.is(res.response, "specific_people");
 });
 
-test("SearchVideosEditorial: withStartDate will include start_date in query", async t => {  
+test("SearchVideosEditorial: withStartDate will include date_from in query", async t => {  
     var client = new api({ apiKey: "apikey", apiSecret: "apisecret" }, null);
     const res = await client.searchvideoseditorial().withPhrase("cat").withStartDate("2023-01-01").execute();
-    t.is(res.response, "start_date");
+    t.is(res.response, "date_from");
 });
 
 test("SearchVideosEditorial: withEndDate will include end_date in query", async t => {  


### PR DESCRIPTION
See the documented Swagger, where we advertise `date_from` / `date_to`, not `start_date` / `end_date`:

- https://api.gettyimages.com/swagger/index.html#/Search/get_v3_search_images_editorial
- https://api.gettyimages.com/swagger/index.html#/Search/get_v3_search_videos_editorial