### PR TITLE
Allow passing in a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/gettyimages-api.svg)](https://badge.fury.io/js/gettyimages-api)
 [![Downloads](https://img.shields.io/npm/dt/gettyimages-api.svg)](http://npm-stat.com/charts.html?package=gettyimages-api)
-[![](https://travis-ci.org/gettyimages/gettyimages-api_nodejs.svg?branch=master)](https://travis-ci.org/gettyimages/gettyimages-api_nodejs)
 [![Coverage Status](https://coveralls.io/repos/github/gettyimages/gettyimages-api_nodejs/badge.svg)](https://coveralls.io/github/gettyimages/gettyimages-api_nodejs)
-[![Code Climate](https://codeclimate.com/github/gettyimages/gettyimages-api_nodejs/badges/gpa.svg)](https://codeclimate.com/github/gettyimages/gettyimages-api_nodejs)
 [![Open Hub](https://img.shields.io/badge/Open-Hub-0185CA.svg)](https://www.openhub.net/p/gettyimages-api_nodejs)
 
 ## Introduction
@@ -36,6 +34,7 @@ See the [NodeJS Release Page](https://github.com/nodejs/release) for info on thi
 If you don't already have an API key, fill out and submit the [contact form](http://engage.gettyimages.com/api-contact) to be connected to our Sales team.
 
 ### Installing the package
+
 The SDK is available as an [npm package](https://www.npmjs.com/package/gettyimages-api). Install in your workspace with:
 
 ```sh
@@ -215,6 +214,7 @@ try {
     console.error("An error occurred while making the custom request:", err);
 }
 ```
+
 ### Add custom parameter and header to a search request
 
 ```javascript
@@ -234,4 +234,30 @@ try {
 } catch (err) {
     console.error("An error occurred while searching for images:", err);
 }
+```
+
+### Reuse a token between instantiations of the client
+
+If you need to create new instances of the client between calls, such as in a
+serverless environment, and want to cache the access token between uses, the SDK
+supports this.
+
+```javascript
+import api from "gettyimages-api";
+// Get the token from your cache. The following line is just an example.
+let token = await getTokenFromCache();
+
+const creds = { apiKey: "your_api_key", apiSecret: "your_api_secret", token: token };
+const client = new api(creds);
+const response = await client.searchimagescreative()
+        .withPage(1)
+        .withPageSize(1)
+        .withPhrase('beach')
+        .execute();
+// get the token from the client, as it could have been updated if it was expired.
+token = client.token;
+
+// Store the token in a cache, e.g. Redis or memcached.
+// The following is just an example.
+await setTokenInCache(token);
 ```

--- a/gettyimages-api.js
+++ b/gettyimages-api.js
@@ -42,6 +42,15 @@ class GettyImagesApi {
     set hostName(value) {
         _hostName.set(this,value);
     }
+
+    get token() {
+        return {
+            access_token: this.creds.token.access_token,
+            token_type: "Bearer",
+            expiration: this.creds.token.expiration
+        };
+    }
+
     constructor(credentials, hostName, authHostName) {
         if (!credentials.apiKey) {
             throw new SdkException("must specify an apiKey");
@@ -58,6 +67,9 @@ class GettyImagesApi {
         this.hostName = hostName;
         this.credentials = credentials;
         this.creds = new Credentials(credentials.apiKey, credentials.apiSecret, credentials.username, credentials.password, credentials.refresh_token, authHostName);
+        if (credentials.token) {
+            this.creds.token = credentials.token;
+        }
     }
 
     getAccessToken() {

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -28,10 +28,10 @@ class Credentials {
         _apiKey.set(this,value);
     }
     
-    get accessToken() {
+    get token() {
         return _accessToken.get(this);
     }    
-    set accessToken(value) {
+    set token(value) {
         _accessToken.set(this,value);
     }
 
@@ -76,12 +76,12 @@ class Credentials {
         var apiSecret = this.apiSecret;
         var username = this.username;
         var password = this.password;
-        var accessToken = this.accessToken;
+        var token = this.token;
         var hostName = this.hostName;
         
         
         if (!this.shouldRefreshToken()) {
-            return accessToken;
+            return token;
         }
 
         var params = {
@@ -107,9 +107,9 @@ class Credentials {
             var expireTime = new Date();
             expireTime.setSeconds(expireTime.getSeconds() + Number(response.expires_in));
             response.expiration = expireTime;
-            self.accessToken = response;
+            self.token = response;
             
-            return self.accessToken;
+            return self.token;
         } catch (err) {
             return null;
         }
@@ -139,9 +139,9 @@ class Credentials {
             var expireTime = new Date();
             expireTime.setSeconds(expireTime.getSeconds() + Number(response.expires_in));
             response.expiration = expireTime;
-            self.accessToken = response;
+            self.token = response;
             
-            return self.accessToken;
+            return self.token;
         } catch (err) {
             return null;
         }
@@ -150,10 +150,10 @@ class Credentials {
 
 
     shouldRefreshToken() {
-        var accessToken = this.accessToken;
+        var token = this.token;
         
-        if (accessToken && accessToken.expiration) {
-            return new Date(Date.now() - 5000) > accessToken.expiration;
+        if (token && token.expiration) {
+            return new Date(Date.now() - 5000) > token.expiration;
         } else {
             return true;
         }

--- a/tests/auth-cache-tests.js
+++ b/tests/auth-cache-tests.js
@@ -1,0 +1,33 @@
+const api = require("../gettyimages-api");
+const nock = require("nock");
+const test = require("ava");
+var authCount = 0;
+var authScope;
+
+test.beforeEach(() => {
+    authScope = nock("https://authentication.gettyimages.com")
+        .post("/oauth2/token", body => {
+                authCount++;
+                return body.client_id === "apikey" && body.client_secret === "apisecret" && body.grant_type === "client_credentials";
+            })
+        .times(1)
+        .reply(200, {
+            access_token: "client_credentials_access_token",
+            token_type: "Bearer",
+            expires_in: 1800
+        });
+    nock("https://api.gettyimages.com")
+            .get("/v3/search/images/creative")
+            .query({ "phrase": "cat" })
+            .times(2)
+            .reply(200, {response : "phrase"});
+            
+});
+
+test("Authentication call should only be made once because client should use a cached token on the second call.", async t => {  
+    var client = new api({ apiKey: "apikey", apiSecret: "apisecret" });
+    await client.searchimagescreative().withPhrase("cat").execute();
+    console.log(JSON.stringify(client.token, null, 2));
+    await client.searchimagescreative().withPhrase("cat").execute();
+    t.is(authCount, 1, "Authentication call should only be made once because client should use a cached token on the second call.");
+});

--- a/tests/auth-cache-tests.js
+++ b/tests/auth-cache-tests.js
@@ -4,36 +4,36 @@ const test = require("ava");
 var authCount = 0;
 
 test.beforeEach(() => {
-  nock("https://authentication.gettyimages.com")
-    .post("/oauth2/token", (body) => {
-      authCount++;
-      return (
-        body.client_id === "apikey" &&
-        body.client_secret === "apisecret" &&
-        body.grant_type === "client_credentials"
-      );
-    })
-    .times(1)
-    .reply(200, {
-      access_token: "client_credentials_access_token",
-      token_type: "Bearer",
-      expires_in: 1800,
-    });
-  nock("https://api.gettyimages.com")
-    .get("/v3/search/images/creative")
-    .query({ phrase: "cat" })
-    .times(2)
-    .reply(200, { response: "phrase" });
+    nock("https://authentication.gettyimages.com")
+        .post("/oauth2/token", (body) => {
+            authCount++;
+            return (
+                body.client_id === "apikey" &&
+                body.client_secret === "apisecret" &&
+                body.grant_type === "client_credentials"
+            );
+        })
+        .times(1)
+        .reply(200, {
+            access_token: "client_credentials_access_token",
+            token_type: "Bearer",
+            expires_in: 1800,
+        });
+    nock("https://api.gettyimages.com")
+        .get("/v3/search/images/creative")
+        .query({ phrase: "cat" })
+        .times(2)
+        .reply(200, { response: "phrase" });
 });
 
 test("Authentication call should only be made once because client should use a cached token on the second call.", async (t) => {
-  var client = new api({ apiKey: "apikey", apiSecret: "apisecret" });
-  await client.searchimagescreative().withPhrase("cat").execute();
-  console.log(JSON.stringify(client.token, null, 2));
-  await client.searchimagescreative().withPhrase("cat").execute();
-  t.is(
-    authCount,
-    1,
-    "Authentication call should only be made once because client should use a cached token on the second call."
-  );
+    var client = new api({ apiKey: "apikey", apiSecret: "apisecret" });
+    await client.searchimagescreative().withPhrase("cat").execute();
+    console.log(JSON.stringify(client.token, null, 2));
+    await client.searchimagescreative().withPhrase("cat").execute();
+    t.is(
+        authCount,
+        1,
+        "Authentication call should only be made once because client should use a cached token on the second call."
+    );
 });

--- a/tests/auth-cache-tests.js
+++ b/tests/auth-cache-tests.js
@@ -2,32 +2,38 @@ const api = require("../gettyimages-api");
 const nock = require("nock");
 const test = require("ava");
 var authCount = 0;
-var authScope;
 
 test.beforeEach(() => {
-    authScope = nock("https://authentication.gettyimages.com")
-        .post("/oauth2/token", body => {
-                authCount++;
-                return body.client_id === "apikey" && body.client_secret === "apisecret" && body.grant_type === "client_credentials";
-            })
-        .times(1)
-        .reply(200, {
-            access_token: "client_credentials_access_token",
-            token_type: "Bearer",
-            expires_in: 1800
-        });
-    nock("https://api.gettyimages.com")
-            .get("/v3/search/images/creative")
-            .query({ "phrase": "cat" })
-            .times(2)
-            .reply(200, {response : "phrase"});
-            
+  nock("https://authentication.gettyimages.com")
+    .post("/oauth2/token", (body) => {
+      authCount++;
+      return (
+        body.client_id === "apikey" &&
+        body.client_secret === "apisecret" &&
+        body.grant_type === "client_credentials"
+      );
+    })
+    .times(1)
+    .reply(200, {
+      access_token: "client_credentials_access_token",
+      token_type: "Bearer",
+      expires_in: 1800,
+    });
+  nock("https://api.gettyimages.com")
+    .get("/v3/search/images/creative")
+    .query({ phrase: "cat" })
+    .times(2)
+    .reply(200, { response: "phrase" });
 });
 
-test("Authentication call should only be made once because client should use a cached token on the second call.", async t => {  
-    var client = new api({ apiKey: "apikey", apiSecret: "apisecret" });
-    await client.searchimagescreative().withPhrase("cat").execute();
-    console.log(JSON.stringify(client.token, null, 2));
-    await client.searchimagescreative().withPhrase("cat").execute();
-    t.is(authCount, 1, "Authentication call should only be made once because client should use a cached token on the second call.");
+test("Authentication call should only be made once because client should use a cached token on the second call.", async (t) => {
+  var client = new api({ apiKey: "apikey", apiSecret: "apisecret" });
+  await client.searchimagescreative().withPhrase("cat").execute();
+  console.log(JSON.stringify(client.token, null, 2));
+  await client.searchimagescreative().withPhrase("cat").execute();
+  t.is(
+    authCount,
+    1,
+    "Authentication call should only be made once because client should use a cached token on the second call."
+  );
 });

--- a/tests/auth-set-token.js
+++ b/tests/auth-set-token.js
@@ -1,0 +1,35 @@
+const api = require("../gettyimages-api");
+const nock = require("nock");
+const test = require("ava");
+var authCount = 0;
+var authScope;
+
+test.beforeEach(() => {
+    authScope = nock("https://authentication.gettyimages.com")
+        .post("/oauth2/token", body => {
+                authCount++;
+                return body.client_id === "apikey" && body.client_secret === "apisecret" && body.grant_type === "client_credentials";
+            })
+        .times(0)
+        .reply(200, {
+            access_token: "client_credentials_access_token",
+            token_type: "Bearer",
+            expires_in: 1800
+        });
+    nock("https://api.gettyimages.com")
+            .get("/v3/search/images/creative")
+            .query({ "phrase": "cat" })
+            .times(2)
+            .reply(200, {response : "phrase"});
+            
+});
+
+test("Authentication call should not be made because the token was provided by the caller.", async t => {  
+    var client = new api({ apiKey: "apikey", apiSecret: "apisecret", token: {
+        access_token: "provided_access_token",
+        token_type: "Bearer",
+        expiration: Date.now() + 1800000
+    } });
+    await client.searchimagescreative().withPhrase("cat").execute();
+    t.is(authCount, 0, "Authentication call should not be made because the token was provided by the caller.");
+});

--- a/tests/auth-set-token.js
+++ b/tests/auth-set-token.js
@@ -2,34 +2,44 @@ const api = require("../gettyimages-api");
 const nock = require("nock");
 const test = require("ava");
 var authCount = 0;
-var authScope;
 
 test.beforeEach(() => {
-    authScope = nock("https://authentication.gettyimages.com")
-        .post("/oauth2/token", body => {
-                authCount++;
-                return body.client_id === "apikey" && body.client_secret === "apisecret" && body.grant_type === "client_credentials";
-            })
-        .times(0)
-        .reply(200, {
-            access_token: "client_credentials_access_token",
-            token_type: "Bearer",
-            expires_in: 1800
-        });
-    nock("https://api.gettyimages.com")
-            .get("/v3/search/images/creative")
-            .query({ "phrase": "cat" })
-            .times(2)
-            .reply(200, {response : "phrase"});
-            
+  nock("https://authentication.gettyimages.com")
+    .post("/oauth2/token", (body) => {
+      authCount++;
+      return (
+        body.client_id === "apikey" &&
+        body.client_secret === "apisecret" &&
+        body.grant_type === "client_credentials"
+      );
+    })
+    .times(0)
+    .reply(200, {
+      access_token: "client_credentials_access_token",
+      token_type: "Bearer",
+      expires_in: 1800,
+    });
+  nock("https://api.gettyimages.com")
+    .get("/v3/search/images/creative")
+    .query({ phrase: "cat" })
+    .times(2)
+    .reply(200, { response: "phrase" });
 });
 
-test("Authentication call should not be made because the token was provided by the caller.", async t => {  
-    var client = new api({ apiKey: "apikey", apiSecret: "apisecret", token: {
-        access_token: "provided_access_token",
-        token_type: "Bearer",
-        expiration: Date.now() + 1800000
-    } });
-    await client.searchimagescreative().withPhrase("cat").execute();
-    t.is(authCount, 0, "Authentication call should not be made because the token was provided by the caller.");
+test("Authentication call should not be made because the token was provided by the caller.", async (t) => {
+  var client = new api({
+    apiKey: "apikey",
+    apiSecret: "apisecret",
+    token: {
+      access_token: "provided_access_token",
+      token_type: "Bearer",
+      expiration: Date.now() + 1800000,
+    },
+  });
+  await client.searchimagescreative().withPhrase("cat").execute();
+  t.is(
+    authCount,
+    0,
+    "Authentication call should not be made because the token was provided by the caller."
+  );
 });

--- a/tests/auth-set-token.js
+++ b/tests/auth-set-token.js
@@ -4,42 +4,42 @@ const test = require("ava");
 var authCount = 0;
 
 test.beforeEach(() => {
-  nock("https://authentication.gettyimages.com")
-    .post("/oauth2/token", (body) => {
-      authCount++;
-      return (
-        body.client_id === "apikey" &&
-        body.client_secret === "apisecret" &&
-        body.grant_type === "client_credentials"
-      );
-    })
-    .times(0)
-    .reply(200, {
-      access_token: "client_credentials_access_token",
-      token_type: "Bearer",
-      expires_in: 1800,
-    });
-  nock("https://api.gettyimages.com")
-    .get("/v3/search/images/creative")
-    .query({ phrase: "cat" })
-    .times(2)
-    .reply(200, { response: "phrase" });
+    nock("https://authentication.gettyimages.com")
+        .post("/oauth2/token", (body) => {
+            authCount++;
+            return (
+                body.client_id === "apikey" &&
+                body.client_secret === "apisecret" &&
+                body.grant_type === "client_credentials"
+            );
+        })
+        .times(0)
+        .reply(200, {
+            access_token: "client_credentials_access_token",
+            token_type: "Bearer",
+            expires_in: 1800,
+        });
+    nock("https://api.gettyimages.com")
+        .get("/v3/search/images/creative")
+        .query({ phrase: "cat" })
+        .times(2)
+        .reply(200, { response: "phrase" });
 });
 
 test("Authentication call should not be made because the token was provided by the caller.", async (t) => {
-  var client = new api({
-    apiKey: "apikey",
-    apiSecret: "apisecret",
-    token: {
-      access_token: "provided_access_token",
-      token_type: "Bearer",
-      expiration: Date.now() + 1800000,
-    },
-  });
-  await client.searchimagescreative().withPhrase("cat").execute();
-  t.is(
-    authCount,
-    0,
-    "Authentication call should not be made because the token was provided by the caller."
-  );
+    var client = new api({
+        apiKey: "apikey",
+        apiSecret: "apisecret",
+        token: {
+            access_token: "provided_access_token",
+            token_type: "Bearer",
+            expiration: Date.now() + 1800000,
+        },
+    });
+    await client.searchimagescreative().withPhrase("cat").execute();
+    t.is(
+        authCount,
+        0,
+        "Authentication call should not be made because the token was provided by the caller."
+    );
 });

--- a/tests/authtests.js
+++ b/tests/authtests.js
@@ -8,20 +8,20 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         })
         .post("/oauth2/token", "client_id=apikey&client_secret=apisecret&grant_type=password&username=username&password=password")
         .reply(200, {
             access_token: "resource_owner_access_token",
             token_type: "Bearer",
-            expires_in: "1800",
+            expires_in: 1800,
             refresh_token: "refreshtoken"
         })
         .post("/oauth2/token", "client_id=apikey&client_secret=apisecret&refresh_token=refreshtoken&grant_type=refresh_token")
         .reply(200, {
             access_token: "accesstoken",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
 });
 

--- a/tests/collectionstests.js
+++ b/tests/collectionstests.js
@@ -8,7 +8,7 @@ test.before(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/collections")

--- a/tests/countriestests.js
+++ b/tests/countriestests.js
@@ -8,7 +8,7 @@ test.before(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/countries")

--- a/tests/customparamsandheaderstests.js
+++ b/tests/customparamsandheaderstests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/search/images/creative")

--- a/tests/customrequesttests.js
+++ b/tests/customrequesttests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/search/images")

--- a/tests/downloadsimagestests.js
+++ b/tests/downloadsimagestests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .post("/v3/downloads/images/123")

--- a/tests/downloadsvideostests.js
+++ b/tests/downloadsvideostests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .post("/v3/downloads/videos/123")

--- a/tests/eventstests.js
+++ b/tests/eventstests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/events/123")

--- a/tests/imagestests.js
+++ b/tests/imagestests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/images/123")

--- a/tests/searchimagescreativetests.js
+++ b/tests/searchimagescreativetests.js
@@ -8,7 +8,7 @@ test.beforeEach( () => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/search/images/creative")

--- a/tests/searchimageseditorialtests.js
+++ b/tests/searchimageseditorialtests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/search/images/editorial")

--- a/tests/searchimagestests.js
+++ b/tests/searchimagestests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/search/images")

--- a/tests/searchvideoscreativetests.js
+++ b/tests/searchvideoscreativetests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/search/videos/creative")

--- a/tests/searchvideoseditorialtests.js
+++ b/tests/searchvideoseditorialtests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/search/videos/editorial")

--- a/tests/searchvideostests.js
+++ b/tests/searchvideostests.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/search/videos")

--- a/tests/videostests.js
+++ b/tests/videostests.js
@@ -8,7 +8,7 @@ test.beforeEach( () => {
         .reply(200, {
             access_token: "client_credentials_access_token",
             token_type: "Bearer",
-            expires_in: "1800"
+            expires_in: 1800
         });
     nock("https://api.gettyimages.com")
         .get("/v3/videos/123")


### PR DESCRIPTION
Changes to allow the token info to be retrieved and set on the API client. This is useful when running across multiple servers or when running in a serverless environment.

Closes #70