### PR TITLE
Bump brace-expansion from 1.1.11 to 1.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1165,9 +1165,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5717,9 +5717,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
## Summary
- Fixes [Dependabot alert #60](https://github.com/gettyimages/gettyimages-api_nodejs/security/dependabot/60) (GHSA-3jxr-9vmj-r5cp / CVE-2026-13149)
- `brace-expansion` had exponential-time behavior on consecutive non-expanding `{}` groups, allowing a small input to hang the process
- It's a transitive dev dependency (`eslint-plugin-import` → `minimatch` → `brace-expansion`); bumped the lockfile entry from 1.1.11 to 1.1.16, the first patched version in the 1.x line

## Test plan
- [x] `npm ci` installs cleanly and resolves `brace-expansion@1.1.16`
- [x] `npm test` — all 164 tests pass
