### PR TITLE
Fix js-yaml quadratic CPU vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3230,10 +3230,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5179,7 +5180,7 @@
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -5223,7 +5224,7 @@
       "requires": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "resolve-from": "^5.0.0"
       }
     },
@@ -6225,7 +6226,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -7252,9 +7253,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -7515,7 +7516,7 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "make-dir": "^3.0.0",
         "node-preload": "^0.2.0",
         "p-map": "^3.0.0",
@@ -8108,7 +8109,7 @@
       "dev": true,
       "requires": {
         "indent-string": "^5.0.0",
-        "js-yaml": "^3.14.1",
+        "js-yaml": "^3.15.0",
         "serialize-error": "^7.0.1",
         "strip-ansi": "^7.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "nock": "^12.0.1",
     "nyc": "^15.0.0"
   },
+  "overrides": {
+    "js-yaml": "^3.15.0"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/gettyimages/gettyimages-api_nodejs.git"


### PR DESCRIPTION
## Summary

- Pin the transitive dev dependency js-yaml to 3.15.0 or later with a package.json override.
- js-yaml before 3.15.0 can spend quadratic CPU time on a YAML document that chains merge keys, which is a high-severity denial-of-service issue (GHSA-52cp-r559-cp3m, CVE-2026-59869).
- Resolves Dependabot alert https://github.com/gettyimages/gettyimages-api_nodejs/security/dependabot/61.

## Test plan

- [x] Ran `npm install` and confirmed js-yaml resolves to 3.15.1 in package-lock.json.
- [x] Ran `npm test`; all 164 tests pass.